### PR TITLE
Don't accumulate logs during tests

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -30,11 +30,13 @@ class Logger {
   }
 
   _log(type, style, level, message, error) {
-    this.logs.push({
-      type,
-      message,
-      error
-    });
+    if (process.env.NODE_ENV !== "test") {
+      this.logs.push({
+        type,
+        message,
+        error
+      });
+    }
 
     if (level < this.loglevel) {
       return;


### PR DESCRIPTION
This is a leak that can cause slowdown and even eventually failure (see #6).
