### PR TITLE
Validate and standardize exposure of command classes

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -22,7 +22,7 @@ export default class Command {
 
   get name() {
     // For a class named "FooCommand" this returns "foo".
-    return this.className.replace("Command", "").toLowerCase();
+    return commandNameFromClassName(this.className);
   }
 
   get className() {
@@ -225,4 +225,25 @@ export default class Command {
   execute() {
     throw new Error("command.execute() needs to be implemented.");
   }
+}
+
+export function commandNameFromClassName(className) {
+  return className.replace("Command", "").toLowerCase();
+}
+
+export function exposeCommands(obj, commands) {
+  commands.forEach((cls) => {
+    const commandName = commandNameFromClassName(cls.name);
+    if (!cls.name.match(/Command$/)) {
+      throw new Error(`Invalid command class name "${cls.name}".  Must end with "Command".`);
+    }
+    if (obj[commandName]) {
+      throw new Error(`Duplicate command: "${commandName}"`);
+    }
+    if (!Command.isPrototypeOf(cls)) {
+      throw new Error(`Command does not extend Command: "${cls.name}"`);
+    }
+    obj[commandName] = cls;
+  });
+  return obj;
 }

--- a/src/Command.js
+++ b/src/Command.js
@@ -228,7 +228,7 @@ export default class Command {
 }
 
 export function commandNameFromClassName(className) {
-  return className.replace("Command", "").toLowerCase();
+  return className.replace(/Command$/, "").toLowerCase();
 }
 
 export function exposeCommands(commands) {

--- a/src/Command.js
+++ b/src/Command.js
@@ -231,8 +231,8 @@ export function commandNameFromClassName(className) {
   return className.replace("Command", "").toLowerCase();
 }
 
-export function exposeCommands(obj, commands) {
-  commands.forEach((cls) => {
+export function exposeCommands(commands) {
+  return commands.reduce((obj, cls) => {
     const commandName = commandNameFromClassName(cls.name);
     if (!cls.name.match(/Command$/)) {
       throw new Error(`Invalid command class name "${cls.name}".  Must end with "Command".`);
@@ -244,6 +244,6 @@ export function exposeCommands(obj, commands) {
       throw new Error(`Command does not extend Command: "${cls.name}"`);
     }
     obj[commandName] = cls;
-  });
-  return obj;
+    return obj;
+  }, {});
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,19 +8,22 @@ import InitCommand from "./commands/InitCommand";
 import RunCommand from "./commands/RunCommand";
 import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
+import {exposeCommands} from "./Command";
 
-export const __commands__ = {
-  bootstrap: BootstrapCommand,
-  publish: PublishCommand,
-  updated: UpdatedCommand,
-  import: ImportCommand,
-  clean: CleanCommand,
-  diff: DiffCommand,
-  init: InitCommand,
-  run: RunCommand,
-  exec: ExecCommand,
-  ls: LsCommand
-};
+export const __commands__ = {};
+
+exposeCommands(__commands__, [
+  BootstrapCommand,
+  PublishCommand,
+  UpdatedCommand,
+  ImportCommand,
+  CleanCommand,
+  DiffCommand,
+  InitCommand,
+  RunCommand,
+  ExecCommand,
+  LsCommand,
+]);
 
 import PackageUtilities from "./PackageUtilities";
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,7 @@ import ExecCommand from "./commands/ExecCommand";
 import LsCommand from "./commands/LsCommand";
 import {exposeCommands} from "./Command";
 
-export const __commands__ = {};
-
-exposeCommands(__commands__, [
+export const __commands__ = exposeCommands([
   BootstrapCommand,
   PublishCommand,
   UpdatedCommand,

--- a/test/Command.js
+++ b/test/Command.js
@@ -195,27 +195,19 @@ describe("Command", () => {
     }
 
     it("makes a mapping from command names to classes", () => {
-      assert.deepEqual(exposeCommands({}, [FooCommand, BarCommand]), {
-        foo: FooCommand,
-        bar: BarCommand,
-      });
-    });
-    it("mutates the mapping that's passed in", () => {
-      const mapping = {};
-      exposeCommands(mapping, [FooCommand, BarCommand]);
-      assert.deepEqual(mapping, {
+      assert.deepEqual(exposeCommands([FooCommand, BarCommand]), {
         foo: FooCommand,
         bar: BarCommand,
       });
     });
     it("fails on bad class name", () => {
-      assert.throws(() => exposeCommands({}, [BadClassName]));
+      assert.throws(() => exposeCommands([BadClassName]));
     });
     it("fails on duplicate class", () => {
-      assert.throws(() => exposeCommands({}, [FooCommand, FooCommand]));
+      assert.throws(() => exposeCommands([FooCommand, FooCommand]));
     });
     it("fails on class that doesn't extend Command", () => {
-      assert.throws(() => exposeCommands({}, [NonCommand]));
+      assert.throws(() => exposeCommands([NonCommand]));
     });
   });
 });

--- a/test/Command.js
+++ b/test/Command.js
@@ -3,6 +3,7 @@ import assert from "assert";
 import progressBar from "../src/progressBar";
 import initFixture from "./_initFixture";
 import Command from "../src/Command";
+import {exposeCommands} from "../src/Command";
 import logger from "../src/logger";
 import stub from "./_stub";
 
@@ -180,6 +181,41 @@ describe("Command", () => {
       it("should not provide a value to other commands", () => {
         assert.equal(new TestCommand([], {}).getOptions().ignore, undefined);
       });
+    });
+  });
+
+  describe("exposeCommands", () => {
+    class FooCommand extends Command {
+    }
+    class BarCommand extends Command {
+    }
+    class BadClassName extends Command {
+    }
+    class NonCommand {
+    }
+
+    it("makes a mapping from command names to classes", () => {
+      assert.deepEqual(exposeCommands({}, [FooCommand, BarCommand]), {
+        foo: FooCommand,
+        bar: BarCommand,
+      });
+    });
+    it("mutates the mapping that's passed in", () => {
+      const mapping = {};
+      exposeCommands(mapping, [FooCommand, BarCommand]);
+      assert.deepEqual(mapping, {
+        foo: FooCommand,
+        bar: BarCommand,
+      });
+    });
+    it("fails on bad class name", () => {
+      assert.throws(() => exposeCommands({}, [BadClassName]));
+    });
+    it("fails on duplicate class", () => {
+      assert.throws(() => exposeCommands({}, [FooCommand, FooCommand]));
+    });
+    it("fails on class that doesn't extend Command", () => {
+      assert.throws(() => exposeCommands({}, [NonCommand]));
     });
   });
 });


### PR DESCRIPTION
Groundwork for pluggable commands.

Ensure that command classes:
- Are named `*Command`
- Are uniquely named
- Extend the `Command` base class
