### PR TITLE
Change bootstrap command to not install peerDependencies (#318)

### DIFF
--- a/src/Package.js
+++ b/src/Package.js
@@ -49,7 +49,6 @@ export default class Package {
   get allDependencies() {
     return objectAssign(
       {},
-      this.peerDependencies,
       this.devDependencies,
       this.dependencies
     );

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -401,4 +401,43 @@ describe("BootstrapCommand", () => {
       }));
     });
   });
+
+  describe("peer dependencies in packages in the repo", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("BootstrapCommand/peer", done);
+    });
+
+    it("should not bootstrap ignored peer dependencies", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {
+        "ignore-peer-deps": true
+      });
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      let installed = false;
+      stub(ChildProcessUtilities, "spawn", (command, args, options, callback) => {
+        // This should never be reached
+        assert.deepEqual(args, ["install", "external@^1.0.0"]);
+        assert.deepEqual(options, { cwd: path.join(testDir, "packages/package-1"), stdio: STDIO_OPT });
+        installed = true;
+        callback();
+      });
+
+      bootstrapCommand.runCommand(exitWithCode(0, (err) => {
+        if (err) return done(err);
+
+        try {
+          assert.ok(!pathExists.sync(path.join(testDir, "asini-debug.log")), "asini-debug.log should not exist");
+          assert.ok(!pathExists.sync(path.join(testDir, "packages/package-1/node_modules/package-2")), "The linkable peer dependency should not be installed");
+          assert.ok(!installed, "The external peer dependency should not be installed");
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }));
+    });
+  });
 });

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -410,9 +410,7 @@ describe("BootstrapCommand", () => {
     });
 
     it("should not bootstrap ignored peer dependencies", (done) => {
-      const bootstrapCommand = new BootstrapCommand([], {
-        "ignore-peer-deps": true
-      });
+      const bootstrapCommand = new BootstrapCommand([], {});
 
       bootstrapCommand.runValidations();
       bootstrapCommand.runPreparations();

--- a/test/Package.js
+++ b/test/Package.js
@@ -75,8 +75,7 @@ describe("Package", () => {
     it("should return the combined dependencies", () => {
       assert.deepEqual(pkg.allDependencies, {
         "my-dependency": "^1.0.0",
-        "my-dev-dependency": "^1.0.0",
-        "my-peer-dependency": "^1.0.0"
+        "my-dev-dependency": "^1.0.0"
       });
     });
   });

--- a/test/fixtures/BootstrapCommand/peer/asini.json
+++ b/test/fixtures/BootstrapCommand/peer/asini.json
@@ -1,0 +1,4 @@
+{
+  "asini": "__TEST_VERSION__",
+  "version": "1.0.0"
+}

--- a/test/fixtures/BootstrapCommand/peer/package.json
+++ b/test/fixtures/BootstrapCommand/peer/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
+++ b/test/fixtures/BootstrapCommand/peer/packages/package-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-1",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "external": "^1.0.0",
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/BootstrapCommand/peer/packages/package-2/package.json
+++ b/test/fixtures/BootstrapCommand/peer/packages/package-2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-2",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
As of npm@3, peerDependencies were no longer installed with
`npm install`. The bootstrap command should conform to this behaviour.
