### PR TITLE
Log stdout on ChildProcessUtilities.exec errors (fixes #11)

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -3,6 +3,7 @@ import spawn from "cross-spawn";
 import objectAssign from "object-assign";
 import syncExec from "sync-exec";
 import {EventEmitter} from "events";
+import logger from "./logger";
 
 // Keep track of how many live children we have.
 let children = 0;
@@ -21,6 +22,9 @@ export default class ChildProcessUtilities {
     return ChildProcessUtilities.registerChild(
       child.exec(command, mergedOpts, (err, stdout, stderr) => {
         if (err != null) {
+
+          // output stdout on error
+          logger.info(stdout);
 
           // If the error from `child.exec` is just that the child process
           // emitted too much on stderr, then that stderr output is likely to

--- a/src/commands/RunCommand.js
+++ b/src/commands/RunCommand.js
@@ -42,8 +42,7 @@ export default class RunCommand extends Command {
   }
 
   runScriptInPackage(pkg, callback) {
-    NpmUtilities.runScriptInDir(this.script, this.args, pkg.location, (err, stdout) => {
-      this.logger.info(stdout);
+    NpmUtilities.runScriptInDir(this.script, this.args, pkg.location, (err) => {
       if (err) {
         this.logger.error(`Errored while running npm script '${this.script}' in '${pkg.name}'`, err);
       }


### PR DESCRIPTION
This removes the logging from the Run command as it's no longer necessary.
