### PR TITLE
Adding Slack badge that links to Slackin service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<p align="center">
-  A tool for managing JavaScript projects with multiple packages.
-</p>
+A tool for managing JavaScript projects with multiple packages.
 
-<p align="center">
-  <a href="https://www.npmjs.com/package/asini"><img alt="NPM Status" src="https://img.shields.io/npm/v/asini.svg?style=flat"></a>
-  <a href="https://travis-ci.org/asini/asini"><img alt="Travis Status" src="https://img.shields.io/travis/asini/asini/master.svg?style=flat&label=travis"></a>
-  <a href="https://ci.appveyor.com/project/gigabo/asini"><img alt="Appveyor Status" src="https://img.shields.io/appveyor/ci/gigabo/asini.svg"></a>
-</p>
+[![NPM Status][npm-status-img]][npm-url]
+[![Travis Status][travis-status-img]][travis-url]
+[![Appveyor Status][appveyor-status-img]][appveyor-url]
 
 ## About
 
@@ -535,3 +531,10 @@ Ex: in Babel, `babel-types` is depended upon by all packages in the monorepo (ov
 What level of logs to report.  On failure, all logs are written to asini-debug.log in the current working directory.
 
 Any logs of a higher level than the setting are shown.  The default is "info".
+
+[npm-status-img]: https://img.shields.io/npm/v/asini.svg?style=flat
+[npm-url]: https://www.npmjs.com/package/asini
+[travis-status-img]: https://img.shields.io/travis/asini/asini/master.svg?style=flat&label=travis
+[travis-url]: https://travis-ci.org/asini/asini
+[appveyor-status-img]: https://img.shields.io/appveyor/ci/gigabo/asini.svg
+[appveyor-url]: https://ci.appveyor.com/project/gigabo/asini

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A tool for managing JavaScript projects with multiple packages.
 [![NPM Status][npm-status-img]][npm-url]
 [![Travis Status][travis-status-img]][travis-url]
 [![Appveyor Status][appveyor-status-img]][appveyor-url]
+[![Chat on Slack][slack-img]][slack-url]
 
 ## About
 
@@ -538,3 +539,5 @@ Any logs of a higher level than the setting are shown.  The default is "info".
 [travis-url]: https://travis-ci.org/asini/asini
 [appveyor-status-img]: https://img.shields.io/appveyor/ci/gigabo/asini.svg
 [appveyor-url]: https://ci.appveyor.com/project/gigabo/asini
+[slack-url]: https://slack.asini.io/
+[slack-img]: https://slack.asini.io/badge.svg


### PR DESCRIPTION
- Decentering the text and badges at the top of the README to simplify the README.
- Adding a Slack badge that links to the Asini Slackin service.

Here is how it looks:
![image](https://cloud.githubusercontent.com/assets/933552/19142355/b4347e4c-8b51-11e6-8823-750babc731ca.png)
