### PR TITLE
Use default text color for `logger.info` output

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -9,7 +9,7 @@ const DEFAULT_LOGLEVEL = "info";
 const LEVELS = [
   [ "silly",   "magenta" ],
   [ "verbose", "blue"    ],
-  [ "info",    "white"   ],
+  [ "info",    "reset"   ],
   [ "success", "green"   ],
   [ "warn",    "yellow"  ],
   [ "error",   "red"     ],


### PR DESCRIPTION
White text doesn't work well with white terminal backgrounds.

See https://github.com/lerna/lerna/issues/366.
