### PR TITLE
fix: lerna init assumes lerna in devDependencies

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -31,6 +31,20 @@ export default class InitCommand extends Command {
       this.logger.info("Updating package.json.");
     }
 
+    let targetDependencies;
+    if (packageJson.dependencies && packageJson.dependencies.lerna) {
+      // lerna is a dependency in the current project
+      targetDependencies = packageJson.dependencies;
+    } else {
+      // lerna is a devDependency or no dependency, yet
+      if (!packageJson.devDependencies) packageJson.devDependencies = {};
+      targetDependencies = packageJson.devDependencies;
+    }
+
+    objectAssignSorted(targetDependencies, {
+      lerna: this.lernaVersion
+    });
+
     // if (!packageJson.private) packageJson.private = true;
     if (!packageJson.devDependencies) packageJson.devDependencies = {};
 


### PR DESCRIPTION
From the [original PR](https://github.com/lerna/lerna/pull/370):

> The current implementation assumes lerna to be a devDependency. Our project has lerna as a dependency (because the shell project is only build tools, which makes lerna a dependency in that sense). However when we run `lerna init` (after a lerna upgrade for example), lerna gets added to the `devDependencies` and not updated in the dependencies. This PR fixes this.

Need to merge this non-squash to preserve @joscha's authorship.
