### PR TITLE
Automatic hoisting of common dependencies to repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,30 @@ What level of logs to report.  On failure, all logs are written to asini-debug.l
 
 Any logs of a higher level than the setting are shown.  The default is "info".
 
+#### --hoist [glob]
+
+Install external dependencies matching `glob` at the repo root so they're
+available to all packages.  Any binaries from these dependencies will be
+linked into dependent package `node_modules/.bin/` directories so they're
+available for npm scripts.  If no `glob` is given the default is `**` (hoist
+everything).  This option only affects the `bootstrap` command.
+
+```sh
+$ asini bootstrap --hoist
+```
+
+Note: If packages depend on different _versions_ of an external dependency,
+the most commonly used version will be hoisted, and a warning will be emitted.
+
+#### --nohoist [glob]
+
+Do _not_ install external dependencies matching `glob` at the repo root.  This
+can be used to opt out of hoisting for certain dependencies.
+
+```sh
+$ asini bootstrap --hoist --nohoist=babel-*
+```
+
 [npm-status-img]: https://img.shields.io/npm/v/asini.svg?style=flat
 [npm-url]: https://www.npmjs.com/package/asini
 [travis-status-img]: https://img.shields.io/travis/asini/asini/master.svg?style=flat&label=travis

--- a/bin/asini.js
+++ b/bin/asini.js
@@ -27,6 +27,8 @@ var cli = meow([
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --skip-npm           Stop before actually publishing change to npm (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
+  "  --hoist [glob]       Hoist external dependencies matching [glob] to the repo root",
+  "  --nohoist [glob]     Don't hoist external dependencies matching [glob] to the repo root",
   "  --scope [glob]       Restricts the scope to package names matching the given glob.",
   "  --ignore [glob]      Ignores packages with names matching the given glob.",
   "  --force-publish      Force publish for the specified packages (comma-separated) or all packages using * (skips the git diff check for changed packages)",

--- a/bin/asini.js
+++ b/bin/asini.js
@@ -27,7 +27,7 @@ var cli = meow([
   "  --skip-git           Skip commiting, tagging, and pushing git changes (only affects publish)",
   "  --skip-npm           Stop before actually publishing change to npm (only affects publish)",
   "  --npm-tag [tagname]  Publish packages with the specified npm dist-tag",
-  "  --hoist [glob]       Hoist external dependencies matching [glob] to the repo root",
+  "  --hoist [glob]       Install external dependencies matching [glob] to the repo root.  Use with no glob for all.",
   "  --nohoist [glob]     Don't hoist external dependencies matching [glob] to the repo root",
   "  --scope [glob]       Restricts the scope to package names matching the given glob.",
   "  --ignore [glob]      Ignores packages with names matching the given glob.",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cross-spawn": "^4.0.0",
     "glob": "^7.0.6",
     "inquirer": "^0.12.0",
+    "isarray": "^2.0.1",
     "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",
     "meow": "^3.7.0",

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -1,6 +1,8 @@
 import ChildProcessUtilities from "./ChildProcessUtilities";
 import logger from "./logger";
 import escapeArgs from "command-join";
+import path from "path";
+import semver from "semver";
 
 export default class NpmUtilities {
   @logger.logifyAsync
@@ -47,5 +49,15 @@ export default class NpmUtilities {
   @logger.logifyAsync
   static publishTaggedInDir(tag, directory, callback) {
     ChildProcessUtilities.exec("cd " + escapeArgs(directory) + " && npm publish --tag " + tag, null, callback);
+  }
+
+  @logger.logifySync
+  static dependencyIsSatisfied(dir, dependency, needVersion) {
+    const packageJson = path.join(dir, dependency, "package.json");
+    try {
+      return semver.satisfies(require(packageJson).version, needVersion);
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/src/Package.js
+++ b/src/Package.js
@@ -115,14 +115,8 @@ export default class Package {
    * @returns {Boolean}
    */
   hasDependencyInstalled(dependency) {
-    const packageJson = path.join(this.nodeModulesLocation, dependency, "package.json");
-    try {
-      return semver.satisfies(
-        require(packageJson).version,
-        this.allDependencies[dependency]
-      );
-    } catch (e) {
-      return false;
-    }
+    return NpmUtilities.dependencyIsSatisfied(
+      this.nodeModulesLocation, dependency, this.allDependencies[dependency]
+    );
   }
 }

--- a/src/PackageUtilities.js
+++ b/src/PackageUtilities.js
@@ -93,8 +93,9 @@ export default class PackageUtilities {
     if (!glob) return true;
 
     // Include/exlude with no arguments implies splat.
-    // For example: `--hoist` is equivalent to `--hoist=*`.
-    if (glob === true) glob = "*";
+    // For example: `--hoist` is equivalent to `--hoist=**`.
+    // The double star here is to account for scoped packages.
+    if (glob === true) glob = "**";
 
     if (!isArray(glob)) glob = [glob];
 

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,6 +1,7 @@
 import GitUtilities from "./GitUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
 import PackageUtilities from "./PackageUtilities";
+import Package from "./Package";
 import NpmUtilities from "./NpmUtilities";
 import path from "path";
 import logger from "./logger";
@@ -33,6 +34,8 @@ export default class Repository {
     if (FileSystemUtilities.existsSync(this.packageJsonLocation)) {
       this.packageJson = JSON.parse(FileSystemUtilities.readFileSync(this.packageJsonLocation));
     }
+
+    this.package = new Package(this.packageJson, this.rootPath);
   }
 
   get asiniVersion() {

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,6 +1,7 @@
 import GitUtilities from "./GitUtilities";
 import FileSystemUtilities from "./FileSystemUtilities";
 import PackageUtilities from "./PackageUtilities";
+import NpmUtilities from "./NpmUtilities";
 import path from "path";
 import logger from "./logger";
 
@@ -42,6 +43,10 @@ export default class Repository {
     return this.asiniJson.version;
   }
 
+  get nodeModulesLocation() {
+    return path.join(this.rootPath, "node_modules");
+  }
+
   get packageConfigs() {
     return this.asiniJson.packages || [{
       glob: DEFAULT_PACKAGE_GLOB,
@@ -77,5 +82,11 @@ export default class Repository {
     this._packages = PackageUtilities.getPackages(this);
     this._packageGraph = PackageUtilities.getPackageGraph(this._packages);
     this._filteredPackages = PackageUtilities.getFilteredPackages(this._packages, {scope, ignore});
+  }
+
+  hasDependencyInstalled(dependency, version) {
+    return NpmUtilities.dependencyIsSatisfied(
+      this.nodeModulesLocation, dependency, version
+    );
   }
 }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -319,7 +319,7 @@ export default class BootstrapCommand extends Command {
     if (Object.keys(root).length) {
       actions.push((cb) => NpmUtilities.installInDir(
         this.repository.rootPath,
-        root.map(({dependency}) => dependency),
+        root.map(({dependency}) => dependency).filter((dep) => dep),
         (err) => {
           if (err) return cb(err);
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -289,10 +289,12 @@ export default class BootstrapCommand extends Command {
 
         dependents[version].forEach((pkg) => {
 
-          this.logger.warn(
-            `"${pkg}" package depends on ${name}@${version}, ` +
-            `which differs from the hoisted ${name}@${rootVersion}.`
-          );
+          if (rootVersion) {
+            this.logger.warn(
+              `"${pkg}" package depends on ${name}@${version}, ` +
+              `which differs from the hoisted ${name}@${rootVersion}.`
+            );
+          }
 
           // only install dependency if it's not already installed
           if (!findPackage(pkg).hasDependencyInstalled(name)) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -156,11 +156,14 @@ export default class BootstrapCommand extends Command {
    * @returns {Object}
    */
   getDependenciesToInstall(packages = []) {
+
     // find package by name
     const findPackage = (name, version) => find(this.packages, (pkg) => {
       return pkg.name === name && (!version || semver.satisfies(pkg.version, version));
     });
+
     const hasPackage = (name, version) => Boolean(findPackage(name, version));
+
     /**
      * Map of dependency install locations
      *   - keys represent a package name (i.e. "my-component")
@@ -173,6 +176,7 @@ export default class BootstrapCommand extends Command {
      * }
      */
     const installs = { __ROOT__: [] };
+
     /**
      * Map of dependencies to install
      * {
@@ -202,61 +206,79 @@ export default class BootstrapCommand extends Command {
      * }
      */
     const depsToInstall = {};
+
     // get the map of external dependencies to install
     packages.forEach((pkg) => {
+
       // for all package dependencies
       Object.keys(pkg.allDependencies)
-      // map to package or normalized external dependency
+
+        // map to package or normalized external dependency
         .map((name) => findPackage(name, pkg.allDependencies[name]) || { name, version: pkg.allDependencies[name] })
+
         // match external and version mismatched local packages
         .filter((dep) => !hasPackage(dep.name, dep.version) || !pkg.hasMatchingDependency(dep))
+
         .forEach((dep) => {
           const { name, version } = dep;
+
           if (!depsToInstall[name]) {
             depsToInstall[name] = {
               versions: {},
               dependents: {}
             };
           }
+
           // add dependency version
           if (!depsToInstall[name].versions[version]) {
             depsToInstall[name].versions[version] = 1;
           } else {
             depsToInstall[name].versions[version]++;
           }
+
           // add package with required version
           if (!depsToInstall[name].dependents[version]) {
             depsToInstall[name].dependents[version] = [];
           }
+
           depsToInstall[name].dependents[version].push(pkg.name);
         });
     });
+
     // determine where each dependency will be installed
     Object.keys(depsToInstall).forEach((name) => {
       const allVersions = Object.keys(depsToInstall[name].versions);
+
       // create an object whose keys are the number of dependents
       // with values that are the version those dependents need
       const reversedVersions = Object.keys(depsToInstall[name].versions).reduce((versions, version) => {
         versions[depsToInstall[name].versions[version]] = version;
         return versions;
       }, {});
+
       // get the most common version
       const max = Math.max.apply(null, Object.keys(reversedVersions).map((v) => parseInt(v, 10)));
       const commonVersion = reversedVersions[max.toString()];
+
       // get an array of packages that depend on this external module
       const deps = depsToInstall[name].dependents[commonVersion];
+
       // check if the external dependency is not a package with a version mismatch,
       // and is not already installed at root
       if (!hasPackage(name) && !this.dependencySatisfiesPackages(name, deps.map((dep) => findPackage(dep)))) {
+
         // add the common version to root install
         installs.__ROOT__.push(`${name}@${commonVersion}`);
       }
+
       // add less common versions to package installs
       allVersions.forEach((version) => {
+
         // only install less common versions,
         // unless it's a version-mismatched package
         if (version !== commonVersion || hasPackage(name)) {
           depsToInstall[name].dependents[version].forEach((pkg) => {
+
             // only install dependency if it's not already installed
             if (!findPackage(pkg).hasDependencyInstalled(name)) {
               if (!installs[pkg]) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -267,8 +267,12 @@ export default class BootstrapCommand extends Command {
       // and is not already installed at root
       if (!hasPackage(name) && !this.dependencySatisfiesPackages(name, deps.map((dep) => findPackage(dep)))) {
 
-        // add the common version to root install
-        installs.__ROOT__.push(`${name}@${commonVersion}`);
+        // Only need to install if not already satisfied.
+        if (!NpmUtilities.dependencyIsSatisfied(this.repository.rootPath, name, commonVersion)) {
+
+          // add the common version to root install
+          installs.__ROOT__.push(`${name}@${commonVersion}`);
+        }
       }
 
       // add less common versions to package installs

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -371,7 +371,6 @@ export default class BootstrapCommand extends Command {
 
       this.logger.info("Installing external dependencies");
 
-      // One extra for the root.
       this.progressBar.init(actions.length);
     }
 

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -339,11 +339,26 @@ export default class BootstrapCommand extends Command {
               cb();
             }
           }), (err) => {
-            this.progressBar.tick("Hoisted");
+            this.progressBar.tick("Install hoisted");
             cb(err);
           });
         }
       ));
+
+      // Remove any hoisted dependencies that may have previously been
+      // installed in package directories.
+      actions.push((cb) => {
+        async.series(root.map(({name, dependents}) => (cb) => {
+          async.series(dependents.map((dep) => (cb) => {
+            FileSystemUtilities.rimraf(
+              path.join(this.packageGraph.get(dep).package.nodeModulesLocation, name), cb
+            );
+          }), cb);
+        }), (err) => {
+          this.progressBar.tick("Prune hoisted");
+          cb(err);
+        });
+      });
     }
 
     if (actions.length) {

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -285,7 +285,7 @@ export default class BootstrapCommand extends Command {
                 installs[pkg] = [];
               }
               installs[pkg].push(`${name}@${version}`);
-              this.logger.warning(
+              this.logger.warn(
                 `"${pkg}" package depends on ${name}@${version}, ` +
                 `which differs from the more common ${name}@${commonVersion}.`
               );

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -247,18 +247,12 @@ export default class BootstrapCommand extends Command {
 
     // determine where each dependency will be installed
     Object.keys(depsToInstall).forEach((name) => {
-      const allVersions = Object.keys(depsToInstall[name].versions);
+      const versionCounts = depsToInstall[name].versions;
+      const allVersions = Object.keys(versionCounts);
 
-      // create an object whose keys are the number of dependents
-      // with values that are the version those dependents need
-      const reversedVersions = Object.keys(depsToInstall[name].versions).reduce((versions, version) => {
-        versions[depsToInstall[name].versions[version]] = version;
-        return versions;
-      }, {});
-
-      // get the most common version
-      const max = Math.max.apply(null, Object.keys(reversedVersions).map((v) => parseInt(v, 10)));
-      const commonVersion = reversedVersions[max.toString()];
+      // Get the most common version.
+      const commonVersion = allVersions
+        .reduce((a, b) => versionCounts[a] > versionCounts[b] ? a : b);
 
       // get an array of packages that depend on this external module
       const deps = depsToInstall[name].dependents[commonVersion];

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -279,16 +279,17 @@ export default class BootstrapCommand extends Command {
         if (version !== commonVersion || hasPackage(name)) {
           depsToInstall[name].dependents[version].forEach((pkg) => {
 
+            this.logger.warn(
+              `"${pkg}" package depends on ${name}@${version}, ` +
+              `which differs from the more common ${name}@${commonVersion}.`
+            );
+
             // only install dependency if it's not already installed
             if (!findPackage(pkg).hasDependencyInstalled(name)) {
               if (!installs[pkg]) {
                 installs[pkg] = [];
               }
               installs[pkg].push(`${name}@${version}`);
-              this.logger.warn(
-                `"${pkg}" package depends on ${name}@${version}, ` +
-                `which differs from the more common ${name}@${commonVersion}.`
-              );
             }
           });
         }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -273,7 +273,8 @@ export default class BootstrapCommand extends Command {
         // binaries are linked to the packages that depend on them.
         root.push({
           name,
-          dependents: dependents[rootVersion].map((dep) => this.packageGraph.get(dep).package),
+          dependents: (dependents[rootVersion] || [])
+            .map((dep) => this.packageGraph.get(dep).package),
           dependency: this.repository.hasDependencyInstalled(name, rootVersion)
             ? null // Don't re-install if it's already there.
             : `${name}@${rootVersion}`,

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -164,18 +164,10 @@ export default class BootstrapCommand extends Command {
 
     const hasPackage = (name, version) => Boolean(findPackage(name, version));
 
-    /**
-     * Map of dependency install locations
-     *   - keys represent a package name (i.e. "my-component")
-     *     "__ROOT__" is a special value and refers to the root folder
-     *   - values are an array of strings representing the dependency and its version to install
-     *     (i.e. ["react@15.x", "react-dom@^15.0.0", "webpack@~1.13.0"]
-     *
-     * {
-     *   <package>: [<dependency1@version>, <dependency2@version>, ...]
-     * }
-     */
+    // This will contain entries for each hoistable dependency.
     const root = [];
+
+    // This will map packages to lists of unhoistable dependencies
     const leaves = {};
 
     /**

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -251,7 +251,10 @@ export default class BootstrapCommand extends Command {
       if (!NpmUtilities.dependencyIsSatisfied(this.repository.rootPath, name, commonVersion)) {
 
         // Install the most common version in the repo root.
-        installs.__ROOT__.push(`${name}@${commonVersion}`);
+        installs.__ROOT__.push({
+          dependency: `${name}@${commonVersion}`,
+          dependents: dependents[commonVersion],
+        });
       }
 
       // Add less common versions to package installs.
@@ -269,7 +272,9 @@ export default class BootstrapCommand extends Command {
 
           // only install dependency if it's not already installed
           if (!findPackage(pkg).hasDependencyInstalled(name)) {
-            (installs[pkg] || (installs[pkg] = [])).push(`${name}@${version}`);
+            (installs[pkg] || (installs[pkg] = [])).push({
+              dependency: `${name}@${version}`
+            });
           }
         });
       });

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -5,6 +5,7 @@ import Command from "../Command";
 import async from "async";
 import find from "lodash.find";
 import path from "path";
+import semver from "semver";
 
 export default class BootstrapCommand extends Command {
   initialize(callback) {
@@ -128,6 +129,176 @@ export default class BootstrapCommand extends Command {
     });
     async.series(actions, callback);
   }
+
+  /**
+   * Determine if a dependency installed at the root satifies the requirements of the passed packages
+   * This helps to optimize the bootstrap process and skip dependencies that are already installed
+   * @param {String} dependency
+   * @param {Array.<String>} packages
+   */
+  dependencySatisfiesPackages(dependency, packages) {
+    const packageJson = path.join(this.repository.rootPath, "node_modules", dependency, "package.json");
+    try {
+      return packages.every((pkg) => {
+        return semver.satisfies(
+          require(packageJson).version,
+          pkg.allDependencies[dependency]
+        );
+      });
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Given an array of packages, return map of dependencies to install
+   * @param {Array.<Package>} packages An array of packages
+   * @returns {Object}
+   */
+  getDependenciesToInstall(packages = []) {
+    // find package by name
+    const findPackage = (name, version) => find(this.packages, (pkg) => {
+      return pkg.name === name && (!version || semver.satisfies(pkg.version, version));
+    });
+    const hasPackage = (name, version) => Boolean(findPackage(name, version));
+    /**
+     * Map of dependency install locations
+     *   - keys represent a package name (i.e. "my-component")
+     *     "__ROOT__" is a special value and refers to the root folder
+     *   - values are an array of strings representing the dependency and its version to install
+     *     (i.e. ["react@15.x", "react-dom@^15.0.0", "webpack@~1.13.0"]
+     *
+     * {
+     *   <package>: [<dependency1@version>, <dependency2@version>, ...]
+     * }
+     */
+    const installs = { __ROOT__: [] };
+    /**
+     * Map of dependencies to install
+     * {
+     *   <name>: {
+     *     versions: {
+     *       <version>: <# of dependents>
+     *     },
+     *     dependents: {
+     *       <version>: [<dependent1>, <dependent2>, ...]
+     *     }
+     *   }
+     * }
+     *
+     * Example:
+     *
+     * {
+     *   react: {
+     *     versions: {
+     *       "15.x": 3,
+     *       "^0.14.0": 1
+     *     },
+     *     dependents: {
+     *       "15.x": ["my-component1", "my-component2", "my-component3"],
+     *       "^0.14.0": ["my-component4"],
+     *     }
+     *   }
+     * }
+     */
+    const depsToInstall = {};
+    // get the map of external dependencies to install
+    packages.forEach((pkg) => {
+      // for all package dependencies
+      Object.keys(pkg.allDependencies)
+      // map to package or normalized external dependency
+        .map((name) => findPackage(name, pkg.allDependencies[name]) || { name, version: pkg.allDependencies[name] })
+        // match external and version mismatched local packages
+        .filter((dep) => !hasPackage(dep.name, dep.version) || !pkg.hasMatchingDependency(dep))
+        .forEach((dep) => {
+          const { name, version } = dep;
+          if (!depsToInstall[name]) {
+            depsToInstall[name] = {
+              versions: {},
+              dependents: {}
+            };
+          }
+          // add dependency version
+          if (!depsToInstall[name].versions[version]) {
+            depsToInstall[name].versions[version] = 1;
+          } else {
+            depsToInstall[name].versions[version]++;
+          }
+          // add package with required version
+          if (!depsToInstall[name].dependents[version]) {
+            depsToInstall[name].dependents[version] = [];
+          }
+          depsToInstall[name].dependents[version].push(pkg.name);
+        });
+    });
+    // determine where each dependency will be installed
+    Object.keys(depsToInstall).forEach((name) => {
+      const allVersions = Object.keys(depsToInstall[name].versions);
+      // create an object whose keys are the number of dependents
+      // with values that are the version those dependents need
+      const reversedVersions = Object.keys(depsToInstall[name].versions).reduce((versions, version) => {
+        versions[depsToInstall[name].versions[version]] = version;
+        return versions;
+      }, {});
+      // get the most common version
+      const max = Math.max.apply(null, Object.keys(reversedVersions).map((v) => parseInt(v, 10)));
+      const commonVersion = reversedVersions[max.toString()];
+      // get an array of packages that depend on this external module
+      const deps = depsToInstall[name].dependents[commonVersion];
+      // check if the external dependency is not a package with a version mismatch,
+      // and is not already installed at root
+      if (!hasPackage(name) && !this.dependencySatisfiesPackages(name, deps.map((dep) => findPackage(dep)))) {
+        // add the common version to root install
+        installs.__ROOT__.push(`${name}@${commonVersion}`);
+      }
+      // add less common versions to package installs
+      allVersions.forEach((version) => {
+        // only install less common versions,
+        // unless it's a version-mismatched package
+        if (version !== commonVersion || hasPackage(name)) {
+          depsToInstall[name].dependents[version].forEach((pkg) => {
+            // only install dependency if it's not already installed
+            if (!findPackage(pkg).hasDependencyInstalled(name)) {
+              if (!installs[pkg]) {
+                installs[pkg] = [];
+              }
+              installs[pkg].push(`${name}@${version}`);
+              this.logger.warning(
+                `"${pkg}" package depends on ${name}@${version}, ` +
+                `which differs from the more common ${name}@${commonVersion}.`
+              );
+            }
+          });
+        }
+      });
+    });
+    return installs;
+  }
+
+  /**
+   * Install dependencies for all packages
+   * @param {Object} dependencies
+   * @param {Function} callback
+   */
+  installDependencies(dependencies, callback) {
+    const actions = [];
+    let externalDepsToInstall = 0;
+    Object.keys(dependencies).forEach((dest) => {
+      const destLocation = dest === "__ROOT__"
+        ? this.repository.rootPath
+        : path.join(this.repository.packagesLocation, dest);
+      if (dependencies[dest].length) {
+        externalDepsToInstall += dependencies[dest].length;
+        actions.push((cb) => NpmUtilities.installInDir(destLocation, dependencies[dest], cb));
+      }
+    });
+    if (externalDepsToInstall > 0) {
+      this.logger.info(`Installing ${externalDepsToInstall} external dependencies`);
+    }
+    async.parallelLimit(actions, this.concurrency, callback);
+  }
+
+
 
   /**
    * Install external dependencies for all packages

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -70,6 +70,27 @@ describe("BootstrapCommand", () => {
 
       bootstrapCommand.runCommand(exitWithCode(0, done));
     });
+
+    it("should not hoist when disallowed", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {hoist: true, nohoist: "@test/package-1"});
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
+        ]],
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, done));
+    });
   });
 
 

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -61,10 +61,10 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install", "foo@^1.0.0", "@test/package-1@^0.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
         ]],
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@^1.0.0", "@test/package-1@^0.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
         ]],
       ]);
 
@@ -79,13 +79,13 @@ describe("BootstrapCommand", () => {
 
       assertStubbedCalls([
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
           { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
         ]],
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
           { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
-        ]],
-        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@^1.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
         ]],
       ]);
 

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -46,6 +46,33 @@ describe("BootstrapCommand", () => {
     });
   });
 
+  describe("with hoisting", () => {
+    let testDir;
+
+    beforeEach((done) => {
+      testDir = initFixture("BootstrapCommand/basic", done);
+    });
+
+    it("should hoist", (done) => {
+      const bootstrapCommand = new BootstrapCommand([], {hoist: true});
+
+      bootstrapCommand.runValidations();
+      bootstrapCommand.runPreparations();
+
+      assertStubbedCalls([
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "packages" ,"package-3"), stdio: STDIO_OPT }] }
+        ]],
+        [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
+          { args: ["npm", ["install", "foo@^1.0.0", "@test/package-1@^0.0.0"], { cwd: testDir, stdio: STDIO_OPT }] }
+        ]],
+      ]);
+
+      bootstrapCommand.runCommand(exitWithCode(0, done));
+    });
+  });
+
+
   describe("dependencies between packages in the repo", () => {
     let testDir;
 

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -251,10 +251,10 @@ describe("BootstrapCommand", () => {
           { args: ["npm", ["install", "foo@^1.0.0"], { cwd: path.join(testDir, "packages", "package-2"), stdio: STDIO_OPT }] }
         ]],
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "package-3"), stdio: STDIO_OPT }] }
         ]],
         [ChildProcessUtilities, "spawn", { nodeCallback: true }, [
-          { args: ["npm", ["install", "foo@0.1.12"], { cwd: path.join(testDir, "package-3"), stdio: STDIO_OPT }] }
+          { args: ["npm", ["install", "@test/package-1@^0.0.0"], { cwd: path.join(testDir, "packages", "package-4"), stdio: STDIO_OPT }] }
         ]],
       ]);
 

--- a/test/PackageUtilities.js
+++ b/test/PackageUtilities.js
@@ -77,10 +77,18 @@ describe("PackageUtilities", () => {
       });
     });
 
-    it("should throw when --scope is given but empty", () => {
-      assert.throws(() => {
-        PackageUtilities.filterPackages(packages, "");
-      });
+    it("should return everything when --scope is given but empty", () => {
+      assert.deepEqual(
+        PackageUtilities.filterPackages(packages, "").map((pkg) => pkg.name),
+        ["package-3", "package-4", "package-a-1", "package-a-2"]
+      );
+    });
+
+    it("should return everything when --scope is just true", () => {
+      assert.deepEqual(
+        PackageUtilities.filterPackages(packages, true).map((pkg) => pkg.name),
+        ["package-3", "package-4", "package-a-1", "package-a-2"]
+      );
     });
 
     it("should throw when --scope is given but excludes all packages", () => {


### PR DESCRIPTION
This adds a pair of options to govern installing some or all external dependencies at the repo root instead of distributed in package directories.

From the [original proposal](https://github.com/lerna/lerna/issues/334) for this:

> Hoisting external dependencies that are shared across packages:
> - dramatically speeds up bootstrap
> - reduces the storage footprint of a Lerna repo
> - handles the singleton problem where a common dependency (e.g. React) must be shared

The options may be set on the command lined or in asini.json.

This addresses https://github.com/asini/asini/issues/14.
