### PR TITLE
Make asini an asini repo

### DIFF
--- a/asini.json
+++ b/asini.json
@@ -1,0 +1,17 @@
+{
+  "asini": "1.0.0",
+  "packages": [
+    {
+      "glob": "package.json"
+    }
+  ],
+  "changelog": {
+    "repo": "asini/asini",
+    "labels": {
+      "enhancement": "Enhancement",
+      "bug": "Bug fix"
+    },
+    "cacheDir": ".changelog"
+  },
+  "version": "1.0.0"
+}


### PR DESCRIPTION
This is really just to facilitate changelog generation using `asini-changelog`.

This doesn't start the breakup of Asini into smaller packages.
