### PR TITLE
Reduce the log level of some command output

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -62,10 +62,10 @@ export default class Command {
   }
 
   run() {
-    this.logger.info("Asini v" + this.asiniVersion);
+    this.logger.verbose("Asini v" + this.asiniVersion);
 
     if (this.repository.isIndependent()) {
-      this.logger.info("Independent Versioning Mode");
+      this.logger.verbose("Independent Versioning Mode");
     }
 
     this.runValidations();


### PR DESCRIPTION
The announcement of Asini version and indication of independent mode will no
longer be emitted by default.  They're now `verbose` output.
