### PR TITLE
Log stdout when commands fail

### DIFF
--- a/src/ChildProcessUtilities.js
+++ b/src/ChildProcessUtilities.js
@@ -55,6 +55,7 @@ export default class ChildProcessUtilities {
 
   static spawn(command, args, opts, callback) {
     let stderr = "";
+    let stdout = "";
 
     const childProcess = ChildProcessUtilities.registerChild(
       spawn(command, args, objectAssign({
@@ -62,16 +63,25 @@ export default class ChildProcessUtilities {
       }, opts))
         .on("error", () => {})
         .on("exit", (code) => {
-          callback(code && (stderr || `Command failed: ${command} ${args.join(" ")}`));
+          if (code) {
+            callback(stderr || `Command failed: ${command} ${args.join(" ")}`, stdout);
+          } else {
+            callback(null, stdout);
+          }
         })
     );
 
-    // By default stderr is inherited from us (just sent to _our_ output).
+    // By default stderr, stdout are inherited from us (just sent to _our_ output).
     // If the caller overrode that to "pipe", then we'll gather that up and
     // call back with it in case of failure.
     if (childProcess.stderr) {
       childProcess.stderr.setEncoding("utf8");
       childProcess.stderr.on("data", (chunk) => stderr += chunk);
+    }
+
+    if (childProcess.stdout) {
+      childProcess.stdout.setEncoding("utf8");
+      childProcess.stdout.on("data", (chunk) => stdout += chunk);
     }
   }
 

--- a/src/NpmUtilities.js
+++ b/src/NpmUtilities.js
@@ -13,7 +13,7 @@ export default class NpmUtilities {
 
     const opts = {
       cwd: directory,
-      stdio: ["ignore", "ignore", "pipe"],
+      stdio: ["ignore", "pipe", "pipe"],
     };
 
     ChildProcessUtilities.spawn("npm", args, opts, callback);

--- a/src/logger.js
+++ b/src/logger.js
@@ -80,6 +80,9 @@ class Logger {
       args.push((error, value) => {
         if (error) {
           logger.error(msg);
+          if (value) {
+            logger.error(value);
+          }
         } else {
           logger.silly(msg + " => " + logger._formatValue(value));
         }

--- a/test/BootstrapCommand.js
+++ b/test/BootstrapCommand.js
@@ -13,7 +13,7 @@ import stub from "./_stub";
 
 import assertStubbedCalls from "./_assertStubbedCalls";
 
-const STDIO_OPT = ["ignore", "ignore", "pipe"];
+const STDIO_OPT = ["ignore", "pipe", "pipe"];
 
 describe("BootstrapCommand", () => {
 


### PR DESCRIPTION
ChildProcessUtilities now returns stdout as the second argument of
a callback. logifyAsync will check for the presence of a second
argument and log it out in the case of an error, too.

This fixes #40.

Need to merge this non-squash to preserve @seansfkelley's authorship.
