### PR TITLE
Support more publish config via asini.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ When run with this flag, `publish` will publish to npm without running any of th
 
 > Only publish to npm; skip committing, tagging, and pushing git changes (this only affects publish).
 
+This may be configured in asini.json via `skipGit` or `command.publish.skipGit`.
+
 #### --skip-npm
 
 ```sh
@@ -244,6 +246,8 @@ This flag can be combined with `--skip-git` to _just_ update versions and
 dependencies, without committing, tagging, pushing or publishing.
 
 > Only update versions and dependencies; don't actually publish (this only affects publish).
+
+This may be configured in asini.json via `skipNpm` or `command.publish.skipNpm`.
 
 #### --force-publish [packages]
 

--- a/test/fixtures/PublishCommand/skip/asini.json
+++ b/test/fixtures/PublishCommand/skip/asini.json
@@ -1,0 +1,11 @@
+{
+  "asini": "__TEST_VERSION__",
+  "version": "1.0.0",
+  "command": {
+    "publish": {
+      "//": "These options may appear at the top-level or within publish.  Testing both.",
+      "skipNpm": true
+    }
+  },
+  "skipGit": true
+}

--- a/test/fixtures/PublishCommand/skip/package.json
+++ b/test/fixtures/PublishCommand/skip/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "independent"
+}

--- a/test/fixtures/PublishCommand/skip/packages/package-1/package.json
+++ b/test/fixtures/PublishCommand/skip/packages/package-1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-1",
+  "version": "1.0.0"
+}

--- a/test/fixtures/PublishCommand/skip/packages/package-2/package.json
+++ b/test/fixtures/PublishCommand/skip/packages/package-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/skip/packages/package-3/package.json
+++ b/test/fixtures/PublishCommand/skip/packages/package-3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-3",
+  "version": "1.0.0",
+  "devDependencies": {
+    "package-2": "^1.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/skip/packages/package-4/package.json
+++ b/test/fixtures/PublishCommand/skip/packages/package-4/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-4",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-1": "^0.0.0"
+  }
+}

--- a/test/fixtures/PublishCommand/skip/packages/package-5/package.json
+++ b/test/fixtures/PublishCommand/skip/packages/package-5/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-5",
+  "dependencies": {
+    "package-1": "^1.0.0"
+  },
+  "private": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
The following may now be durably configured in asini.json.

- skipGit
- skipNpm

This was suggested by @dmfenton [here](https://github.com/lerna/lerna/pull/198#issuecomment-259266352).