### PR TITLE
Don't fail bootstrap/run with no packages

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -47,6 +47,12 @@ export default class BootstrapCommand extends Command {
 
   runScriptInPackages(scriptName, callback) {
     const packages = this.filteredPackages.slice();
+
+    // If we don't have any packages, then we have nothing to do.
+    if (!packages.length) {
+      return callback();
+    }
+
     const batches = PackageUtilities.topologicallyBatchPackages(packages, this.logger);
 
     this.progressBar.init(packages.length);


### PR DESCRIPTION
Short-circuit out when trying to run an npm script in an empty list of
packages to avoid an error arising from within the progress bar helper.

This addresses #54.