### PR TITLE
Properly sort added dependency during init

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -32,23 +32,17 @@ export default class InitCommand extends Command {
     }
 
     let targetDependencies;
-    if (packageJson.dependencies && packageJson.dependencies.lerna) {
-      // lerna is a dependency in the current project
-      targetDependencies = packageJson.dependencies;
+    if (packageJson.dependencies && packageJson.dependencies.asini) {
+      // asini is a dependency in the current project
+      targetDependencies = "dependencies";
     } else {
-      // lerna is a devDependency or no dependency, yet
+      // asini is a devDependency or no dependency, yet
       if (!packageJson.devDependencies) packageJson.devDependencies = {};
-      targetDependencies = packageJson.devDependencies;
+      targetDependencies = "devDependencies";
     }
 
-    objectAssignSorted(targetDependencies, {
-      lerna: this.lernaVersion
-    });
-
-    // if (!packageJson.private) packageJson.private = true;
-    if (!packageJson.devDependencies) packageJson.devDependencies = {};
-
-    objectAssignSorted(packageJson.devDependencies, {
+    // updated object must replace targetDependencies, it will not change by reference
+    packageJson[targetDependencies] = objectAssignSorted(packageJson[targetDependencies], {
       asini: this.asiniVersion
     });
 


### PR DESCRIPTION
Unfortunately, there are no tests for the InitCommand. In any case, here's a demonstration of what this patch fixes:

## Before
```sh
$ cat package.json
{
  "name": "test",
  "devDependencies" {
    "eslint": "^3.9.1"
  }
}
$ asini init --loglevel=silent
$ cat package.json
{
  "name": "test",
  "devDependencies" {
    "eslint": "^3.9.1",
    "asini": "1.2.0"
  }
}
```

## After
```sh
$ cat package.json
{
  "name": "test",
  "devDependencies" {
    "eslint": "^3.9.1"
  }
}
$ asini init --loglevel=silent
$ cat package.json
{
  "name": "test",
  "devDependencies" {
    "asini": "1.2.0",
    "eslint": "^3.9.1"
  }
}
```

It seems to do fine with sorting when `asini` already exists, but fails to properly replace the referenced object when `asini` is being added to the dependencies.

I also removed the irrelevant `lerna` stuff.