### PR TITLE
Drop node 0.10/0.12 support and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
   - node_modules
 
 node_js:
- - '0.10'
- - '0.12'
  - '4'
  - '5'
  - '6'

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "url": "https://github.com/asini/asini/issues"
   },
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^2.1.2",
     "chalk": "^1.1.1",
     "cmd-shim": "^2.0.2",
     "command-join": "^1.1.1",
-    "cross-spawn": "^4.0.0",
+    "cross-spawn": "^5.0.1",
     "glob": "^7.0.6",
-    "inquirer": "^0.12.0",
+    "inquirer": "^1.2.3",
     "isarray": "^2.0.1",
     "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",
@@ -40,12 +40,12 @@
     "object-assign": "^4.0.1",
     "object-assign-sorted": "^1.0.0",
     "pad": "^1.0.0",
-    "path-exists": "^2.1.0",
+    "path-exists": "^3.0.0",
     "progress": "^1.1.8",
     "read-cmd-shim": "^1.0.1",
     "rimraf": "^2.4.4",
     "semver": "^5.1.0",
-    "signal-exit": "^2.1.2",
+    "signal-exit": "^3.0.1",
     "sync-exec": "^0.6.2"
   },
   "bin": {
@@ -54,18 +54,18 @@
   "devDependencies": {
     "asini-changelog": "^1.3.0",
     "babel-cli": "^6.7.5",
-    "babel-eslint": "^6.0.2",
+    "babel-eslint": "^7.1.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
-    "cross-env": "^1.0.8",
-    "eslint": "^2.3.0",
-    "eslint-config-babel": "^1.0.1",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flow-vars": "^0.5.0",
-    "fs-extra": "^0.30.0",
-    "mocha": "^2.4.5",
-    "normalize-newline": "^2.1.0"
+    "cross-env": "^3.1.3",
+    "eslint": "^3.10.2",
+    "eslint-config-babel": "^3.0.0",
+    "eslint-plugin-babel": "^4.0.0",
+    "eslint-plugin-flowtype": "^2.25.0",
+    "fs-extra": "^1.0.0",
+    "mocha": "^3.1.2",
+    "normalize-newline": "^3.0.0"
   }
 }

--- a/src/PromptUtilities.js
+++ b/src/PromptUtilities.js
@@ -11,7 +11,7 @@ export default class PromptUtilities {
         { key: "y", name: "Yes", value: true },
         { key: "n", name: "No",  value: false }
       ]
-    }], (answers) => {
+    }]).then((answers) => {
       callback(answers.confirm);
     });
   }
@@ -24,7 +24,7 @@ export default class PromptUtilities {
       choices: choices,
       filter: filter,
       validate: validate
-    }], (answers) => {
+    }]).then((answers) => {
       callback(answers.prompt);
     });
   }
@@ -36,7 +36,7 @@ export default class PromptUtilities {
       message: "Enter a custom version",
       filter: filter,
       validate: validate
-    }], (answers) => {
+    }]).then((answers) => {
       callback(answers.input);
     });
   }

--- a/test/PublishCommand.js
+++ b/test/PublishCommand.js
@@ -765,52 +765,52 @@ describe("PublishCommand", () => {
       publishCommand.runPreparations();
 
       assertStubbedCalls([
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git tag"] }
-       ]],
-       [PromptUtilities, "confirm", { valueCallback: true }, [
-         { args: ["Are you sure you want to publish the above changes?"], returns: true }
-       ]],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["git add " + escapeArgs(path.join(testDir, "asini.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
-         { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
-         { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
-         { args: ["git tag v1.0.1"] }
-       ]],
-       [ChildProcessUtilities, "exec", { nodeCallback: true }, [
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag asini-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag asini-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag asini-temp"] },
-         { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag asini-temp"] }
-         // No package-5.  It's private.
-       ], true],
-       [ChildProcessUtilities, "execSync", {}, [
-         { args: ["npm dist-tag ls package-1"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-1 asini-temp"] },
-         { args: ["npm dist-tag add package-1@1.0.1 latest"] },
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git tag"] }
+        ]],
+        [PromptUtilities, "confirm", { valueCallback: true }, [
+          { args: ["Are you sure you want to publish the above changes?"], returns: true }
+        ]],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["git add " + escapeArgs(path.join(testDir, "asini.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-1/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-2/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-3/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-4/package.json"))] },
+          { args: ["git add " + escapeArgs(path.join(testDir, "packages/package-5/package.json"))] },
+          { args: ["git commit -m \"$(echo \"v1.0.1\")\""] },
+          { args: ["git tag v1.0.1"] }
+        ]],
+        [ChildProcessUtilities, "exec", { nodeCallback: true }, [
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-1")) + " && npm publish --tag asini-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-2")) + " && npm publish --tag asini-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-3")) + " && npm publish --tag asini-temp"] },
+          { args: ["cd " + escapeArgs(path.join(testDir, "packages/package-4")) + " && npm publish --tag asini-temp"] }
+          // No package-5.  It's private.
+        ], true],
+        [ChildProcessUtilities, "execSync", {}, [
+          { args: ["npm dist-tag ls package-1"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-1 asini-temp"] },
+          { args: ["npm dist-tag add package-1@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-2"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-2 asini-temp"] },
-         { args: ["npm dist-tag add package-2@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-2"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-2 asini-temp"] },
+          { args: ["npm dist-tag add package-2@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-3"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-3 asini-temp"] },
-         { args: ["npm dist-tag add package-3@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-3"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-3 asini-temp"] },
+          { args: ["npm dist-tag add package-3@1.0.1 latest"] },
 
-         { args: ["npm dist-tag ls package-4"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
-         { args: ["npm dist-tag rm package-4 asini-temp"] },
-         { args: ["npm dist-tag add package-4@1.0.1 latest"] },
+          { args: ["npm dist-tag ls package-4"], returns: "asini-temp: 1.0.1\nstable: 1.0.0" },
+          { args: ["npm dist-tag rm package-4 asini-temp"] },
+          { args: ["npm dist-tag add package-4@1.0.1 latest"] },
 
-         // No package-5.  It's private.
+          // No package-5.  It's private.
 
-         { args: ["git symbolic-ref --short HEAD"], returns: "master" },
-         { args: ["git push origin master"] },
-         { args: ["git push origin v1.0.1"] }
-       ]],
+          { args: ["git symbolic-ref --short HEAD"], returns: "master" },
+          { args: ["git push origin master"] },
+          { args: ["git push origin v1.0.1"] }
+        ]],
       ]);
 
       publishCommand.runCommand(exitWithCode(0, (err) => {


### PR DESCRIPTION
Had to clean up some indentation due to stricter new eslint.

Had to port inquirer usage to new promise-based interface.

Had to _add_ a dep on `eslint-plugin-flowtype` since `eslint-config-babel` now
requires it as a peerDependency.  Removed `eslint-plugin-flow-vars` as the
other side of that change.

Didn't do asini-changelog deps here.  Will do those separately.