### PR TITLE
Eliminate intra-repo dep cycle and add maintainers docs

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,24 @@
+# Asini Maintainers Handbook
+
+## The Asini Repo
+
+This repository is itself an Asini repo.  In order to avoid cycles in the
+dependency graph the repo root does not depend on itself, so `asini` and
+`asini-changelog` must be installed globally.
+
+```bash
+npm i -g .
+npm i -g packages/asini-changelog
+```
+
+## How to Publish
+
+1. `git checkout master && git pull --rebase`
+1. `asini clean && asini bootstrap`
+1. `asini-changelog >> CHANGELOG.md`
+1. Hand-edit `CHANGELOG.md` to move changes to top and set version
+1. `git add CHANGELOG.md`
+1. `asini publish`
+1. Copy and paste changelog entry into tag notes on GitHub
+1. Link to GitHub tag notes from
+   [`#announcements`](https://asini.slack.com/messages/announcements) on slack

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "asini": "./bin/asini.js"
   },
   "devDependencies": {
-    "asini-changelog": "^1.3.0",
     "babel-cli": "^6.7.5",
     "babel-eslint": "^7.1.1",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
For now just requiring that `asini` and `asini-changelog` be installed
globally for use with the Asini repo.  Eventually the guts of the `asini`
package that `asini-changelog` uses should get pulled out into a dedicated
package (`asini-core`?) so we'll be able to eliminate that global install.
Might make sense to move the CLI into an `asini-cli` package, too, which would
eliminate _that_ global install.

For now, though, just documenting what it takes to publish Asini with globally
installed tools and removing the offending dep.