### PR TITLE
Lint process improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+lib
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules
 lib
 tmp
 .changelog
+.eslintcache

--- a/bin/asini.js
+++ b/bin/asini.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-var */
+// file must remain raw ES5
+
 var asini = require("../lib/index");
 var logger = require("../lib/logger");
 var chalk = require("chalk");

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "build": "babel src -d lib",
     "dev": "babel -w src -d lib",
-    "lint": "eslint src test",
-    "fix": "eslint src test --fix",
+    "lint": "eslint . --cache",
+    "fix": "eslint . --fix",
+    "pretest": "npm run lint",
     "test": "mocha -t 5000",
-    "ci": "npm run lint && cross-env DEBUG_CALLS=true npm run test",
+    "ci": "cross-env DEBUG_CALLS=true npm test",
     "changelog": "asini-changelog",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
* Always run lint during pretest lifecycle (i.e., `npm test` is all you need)
* Lint everything, with a local cache to speed things up

Inspired by #65 