### PR TITLE
Don't prune the repo root when hoisting

### DIFF
--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -354,6 +354,7 @@ export default class BootstrapCommand extends Command {
       actions.push((cb) => {
         async.series(root.map(({name, dependents}) => (cb) => {
           async.series(dependents.map(({nodeModulesLocation: dir}) => (cb) => {
+            if (dir === this.repository.nodeModulesLocation) return cb();
             FileSystemUtilities.rimraf(path.join(dir, name), cb);
           }), cb);
         }), (err) => {


### PR DESCRIPTION
Who would put a package at the repo root.  That's madness.

This eliminates a race condition that causes sporadic failure to bootstrap
_this repository specifically_ with hoisting.

Will follow up with a PR to actually enable said hoisting.