### PR TITLE
Initialize package name with empty string if missing

### DIFF
--- a/src/progressBar.js
+++ b/src/progressBar.js
@@ -35,6 +35,9 @@ class ProgressBarController {
 
   tick(name) {
     if (this.bar) {
+      if (!name) {
+        name = ''
+      }
       this.bar.tick({
         packagename: pad(name.slice(0, 50), 50)
       });


### PR DESCRIPTION
The main cause of https://github.com/asini/asini/issues/54 is that the package name might be missing. I added a workaround for that.